### PR TITLE
chore: remove dead .metanorma/channels.yml

### DIFF
--- a/.metanorma/channels.yml
+++ b/.metanorma/channels.yml
@@ -1,5 +1,0 @@
-# .metanorma/channels.yml — cc-transcription-systems
-
-channels:
-  - name: public/standards
-    description: "CalConnect documents from cc-transcription-systems"


### PR DESCRIPTION
chore: remove dead .metanorma/channels.yml

The metanorma-release gem never reads per-repo .metanorma/channels.yml.
Channel routing is configured in metanorma.release.yml via documents[]
entries. This file was dead code that created confusion about the
architecture.